### PR TITLE
Prevent filter from being invoked twice

### DIFF
--- a/src/main/java/talento/futuro/iotapidev/security/SecurityConfig.java
+++ b/src/main/java/talento/futuro/iotapidev/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package talento.futuro.iotapidev.security;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -47,6 +48,13 @@ public class SecurityConfig {
         http.httpBasic(Customizer.withDefaults());
 
         return http.build();
+    }
+
+    @Bean
+    public FilterRegistrationBean<CompanyApiKeyFilter> companyApiKeyFilterRegistration(CompanyApiKeyFilter filter) {
+        FilterRegistrationBean<CompanyApiKeyFilter> registration = new FilterRegistrationBean<>(filter);
+        registration.setEnabled(false);
+        return registration;
     }
 
     @Bean


### PR DESCRIPTION
Prevent filter from being invoked twice by disabling automatic registration while keeping it as a Spring bean
