### PR TITLE
Cambios menores

### DIFF
--- a/src/main/java/talento/futuro/iotapidev/config/DataSourceConfig.java
+++ b/src/main/java/talento/futuro/iotapidev/config/DataSourceConfig.java
@@ -11,7 +11,6 @@ import javax.sql.DataSource;
 @Configuration
 @RequiredArgsConstructor
 @PropertySource("classpath:database.properties")
-@ComponentScan("talento.futuro.iotapidev")
 @Profile("!test")
 public class DataSourceConfig {
 

--- a/src/main/java/talento/futuro/iotapidev/exception/GlobalExceptionHandler.java
+++ b/src/main/java/talento/futuro/iotapidev/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package talento.futuro.iotapidev.exception;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -12,39 +13,44 @@ import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-
 
     public record ErrorResponse(String message, Integer status, LocalDateTime timestamp) {
     }
 
     @ExceptionHandler(NotFoundException.class)
     public ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException ex) {
+        log.warn("🟠 Resource not found: {}", ex.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
                 new ErrorResponse(ex.getMessage(), HttpStatus.NOT_FOUND.value(), LocalDateTime.now()));
     }
 
     @ExceptionHandler(DuplicatedException.class)
     public ResponseEntity<ErrorResponse> handleDuplicatedException(DuplicatedException ex) {
+        log.warn("🟠 Conflict detected: {}", ex.getMessage());
         return ResponseEntity.status(HttpStatus.CONFLICT).body(
                 new ErrorResponse(ex.getMessage(), HttpStatus.CONFLICT.value(), LocalDateTime.now()));
     }
 
     @ExceptionHandler(InvalidAuthenticationException.class)
     public ResponseEntity<ErrorResponse> handleInvalidAuthenticationException(InvalidAuthenticationException ex) {
+        log.warn("🟠 Authentication failure: {}", ex.getMessage());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
                 new ErrorResponse(ex.getMessage(), HttpStatus.UNAUTHORIZED.value(), LocalDateTime.now()));
     }
 
     @ExceptionHandler(InvalidSensorApiKeyException.class)
     public ResponseEntity<ErrorResponse> handleInvalidSensorApiKeyException(InvalidSensorApiKeyException ex) {
+        log.warn("🟠 Invalid Sensor API Key: {}", ex.getMessage());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
                 new ErrorResponse(ex.getMessage(), HttpStatus.UNAUTHORIZED.value(), LocalDateTime.now()));
     }
 
     @ExceptionHandler(InvalidJSONException.class)
     public ResponseEntity<ErrorResponse> handleInvalidJSONException(InvalidJSONException ex) {
+        log.warn("🟠 Invalid JSON content: {}", ex.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
                 new ErrorResponse(ex.getMessage(), HttpStatus.BAD_REQUEST.value(), LocalDateTime.now()));
     }
@@ -52,6 +58,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Map<String, String>> handleValidationErrors(MethodArgumentNotValidException ex) {
+        log.warn("🟠 Validation failed for object '{}'", ex.getBindingResult().getObjectName());
         Map<String, String> errors = new HashMap<>();
 
         ex.getBindingResult().getFieldErrors().forEach(error ->
@@ -63,14 +70,25 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ErrorResponse> handleBadJson(HttpMessageNotReadableException ex) {
+        log.warn("🟠 Malformed JSON request: {}", ex.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
                 new ErrorResponse("Malformed JSON request", HttpStatus.BAD_REQUEST.value(), LocalDateTime.now()));
     }
 
     @ExceptionHandler(NoHandlerFoundException.class)
     public ResponseEntity<ErrorResponse> handleNotFound(NoHandlerFoundException ex) {
+        log.warn("🟠 Handler not found for {} {}", ex.getHttpMethod(), ex.getRequestURL());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
                 new ErrorResponse("The requested URL was not found: " + ex.getRequestURL(), HttpStatus.BAD_REQUEST.value(), LocalDateTime.now()));
     }
 
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleAnyOtherException(Exception ex) {
+        log.error("🔴 An unexpected error occurred processing request: {}", ex.getMessage(), ex);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+                new ErrorResponse("Unexpected internal server error",
+                        HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                        LocalDateTime.now())
+        );
+    }
 }

--- a/src/main/java/talento/futuro/iotapidev/exception/InvalidSensorApiKeyException.java
+++ b/src/main/java/talento/futuro/iotapidev/exception/InvalidSensorApiKeyException.java
@@ -3,6 +3,12 @@ package talento.futuro.iotapidev.exception;
 
 public class InvalidSensorApiKeyException extends RuntimeException {
     public InvalidSensorApiKeyException(String apikey) {
-        super("Invalid API KEY for sensor: %s.".formatted(apikey));
+        super("Invalid API KEY for sensor API KEY: %s.".formatted(obscureApiKey(apikey)));
     }
+
+    private static String obscureApiKey(String apiKey) {
+        return apiKey.substring(0, 3) + "..." + apiKey.substring(apiKey.length() - 3);
+    }
+
 }
+

--- a/src/main/java/talento/futuro/iotapidev/service/PayloadProcessor.java
+++ b/src/main/java/talento/futuro/iotapidev/service/PayloadProcessor.java
@@ -32,7 +32,7 @@ public class PayloadProcessor {
             String apiKey = payload.apiKey();
 
             Sensor sensor = sensorRepository.findByApiKey(apiKey)
-                    .orElseThrow(() -> new InvalidSensorApiKeyException(apiKey));
+                                            .orElseThrow(() -> new InvalidSensorApiKeyException(apiKey));
 
             JsonNode dataArray = objectMapper.valueToTree(payload.jsonData());
 
@@ -58,10 +58,10 @@ public class PayloadProcessor {
             validatePayload(parsedPayload);
         } catch (MethodArgumentNotValidException e) {
             e.getBindingResult().getAllErrors().stream()
-                    .findFirst()
-                    .ifPresent(error ->
-                            log.error("Error processing JSON: {}", error.getDefaultMessage())
-                    );
+             .findFirst()
+             .ifPresent(error ->
+                     log.error("Error processing JSON: {}", error.getDefaultMessage())
+             );
             throw new InvalidJSONException(e);
         }
 
@@ -78,11 +78,15 @@ public class PayloadProcessor {
     }
 
     private void extractMeasurements(JsonNode dataArray, Sensor sensor) throws IllegalArgumentException {
+
         for (JsonNode measurement : dataArray) {
 
             JsonNode datetime = measurement.get("datetime");
-            if (datetime == null || datetime.isNull()) {
-                throw new IllegalArgumentException();
+
+            if (datetime == null || datetime.isNull() || !datetime.isNumber()) {
+                log.warn("🔸 Invalid 'datetime' field in payload for sensor [{}-ID{}], skipping...",
+                        sensor.getName(), sensor.getId());
+                continue;
             }
             SensorData sensorData = new SensorData();
             sensorData.setTimestamp(datetime.asLong());

--- a/src/main/java/talento/futuro/iotapidev/util/AdminUserInitializer.java
+++ b/src/main/java/talento/futuro/iotapidev/util/AdminUserInitializer.java
@@ -2,11 +2,15 @@ package talento.futuro.iotapidev.util;
 
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import talento.futuro.iotapidev.model.Admin;
 import talento.futuro.iotapidev.repository.AdminRepository;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class AdminUserInitializer {
@@ -14,16 +18,30 @@ public class AdminUserInitializer {
     private final AdminRepository adminRepository;
     private final PasswordEncoder passwordEncoder;
 
+    @Value("${app.security.admin.username}")
+    private String adminUsername;
+
+    @Value("${app.security.admin.password}")
+    private String adminPassword;
+
+
     @PostConstruct
     public void createDefaultAdminUser() {
 
-        if (adminRepository.count() > 0) {
+        if (!StringUtils.hasText(adminUsername) || !StringUtils.hasText(adminPassword)) {
+            log.warn("⚠ Admin username or password not set on ENV. Admin user will not be created.");
             return;
         }
+
+        if (adminRepository.count() > 0) {
+            log.info("👤 Admin user found. Skipping creation.");
+            return;
+        }
+        log.info("👤 Creating default admin user '{}'", adminUsername);
         adminRepository.save(new Admin(
                 null,
-                "admin",
-                passwordEncoder.encode("admin"),
+                adminUsername,
+                passwordEncoder.encode(adminPassword),
                 "ROLE_ADMIN"
         ));
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,10 @@
 spring.application.name=iot-api-dev
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=create-drop
 spring.docker.compose.enabled=${DOCKER_ENABLED:false}
 
 spring.web.resources.add-mappings=false
 logging.level.talento.futuro.iotapidev.security.CompanyApiKeyFilter=DEBUG
 
 
+app.security.admin.username=${ADMIN_USERNAME}
+app.security.admin.password=${ADMIN_PASSWORD}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,5 @@
 spring.application.name=iot-api-dev
-spring.jpa.hibernate.ddl-auto=create-drop
-spring.docker.compose.enabled=${DOCKER_ENABLED:false}
+spring.jpa.hibernate.ddl-auto=update
 
 spring.web.resources.add-mappings=false
 logging.level.talento.futuro.iotapidev.security.CompanyApiKeyFilter=DEBUG

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 spring.application.name=iot-api-dev
 spring.jpa.hibernate.ddl-auto=update
+spring.docker.compose.enabled=${DOCKER_ENABLED:false}
 
 spring.web.resources.add-mappings=false
 logging.level.talento.futuro.iotapidev.security.CompanyApiKeyFilter=DEBUG


### PR DESCRIPTION
### AdminUserInitializer
- Se externalizan las credenciales del usuario admin, ahora deben ser definidas en las variables de entorno:
`ADMIN_USERNAME=username`
`ADMIN_PASSWORD=password`
De lo contrario, no se creara el admin en la db.

### PayloadProcessor:
- Se agrega validacion en caso de que datetime no sea un numero, ya que estamos guardandolo como Long en la db.
- En lugar de lanzar un error si uno de los 'measurement' es invalido, lo saltamos, asi evitamos perder el resto de las lecturas en caso de que el array traiga multiples 'measurements'.

### GlobalExceptionHandler:
- Se agrega ExceptionHandler general que 'atrape' cualquier otra excepcion inesperada, para evitar mostrar stack traces de excepciones en errores inesperados.
- Se agregan logs en cada handler

### Otros:
- Se quita la anotacion @ComponentScan en DataSourceConfig, ya que es redundante con @SpringBootApplication
