### PR TITLE
Consumer/adjustments

### DIFF
--- a/src/main/java/talento/futuro/iotapidev/config/ActiveMQConfig.java
+++ b/src/main/java/talento/futuro/iotapidev/config/ActiveMQConfig.java
@@ -21,7 +21,6 @@ public class ActiveMQConfig {
         DefaultJmsListenerContainerFactory factory = new DefaultJmsListenerContainerFactory();
         factory.setConnectionFactory(connectionFactory);
         factory.setConcurrency(concurrency);
-        factory.setPubSubDomain(true);
         factory.setSessionTransacted(true);
 
         return factory;

--- a/src/main/java/talento/futuro/iotapidev/config/ActiveMQConfig.java
+++ b/src/main/java/talento/futuro/iotapidev/config/ActiveMQConfig.java
@@ -1,6 +1,8 @@
 package talento.futuro.iotapidev.config;
 
 import jakarta.jms.ConnectionFactory;
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.RedeliveryPolicy;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,16 +16,58 @@ import org.springframework.jms.support.converter.SimpleMessageConverter;
 @PropertySource("classpath:activemq.properties")
 public class ActiveMQConfig {
 
+    @Value("${spring.activemq.broker-url}")
+    private String brokerUrl;
+
+    @Value("${spring.activemq.user}")
+    private String username;
+
+    @Value("${spring.activemq.password}")
+    private String password;
+
+    @Value("${spring.activemq.packages.trust-all:false}")
+    private boolean trustAllPackages;
+
     @Value("${app.activemq.listener.concurrency}")
     private String concurrency;
 
+    @Value("${app.activemq.redelivery.maximum-redeliveries}")
+    private int maximumRedeliveries;
+
+    @Value("${app.activemq.redelivery.initial-redelivery-delay}")
+    private int initialRedeliveryDelay;
+
+    @Value("${app.activemq.redelivery.redelivery-delay}")
+    private int redeliveryDelay;
+
+    @Value("${app.activemq.redelivery.use-exponential-backoff}")
+    private boolean useExponentialBackoff;
+
     @Bean
-    public DefaultJmsListenerContainerFactory jmsTransactionalContainerFactory (ConnectionFactory connectionFactory) {
+    public DefaultJmsListenerContainerFactory jmsTransactionalContainerFactory (ConnectionFactory activeMQConnectionFactory) {
         DefaultJmsListenerContainerFactory factory = new DefaultJmsListenerContainerFactory();
-        factory.setConnectionFactory(connectionFactory);
+        factory.setConnectionFactory(activeMQConnectionFactory);
         factory.setConcurrency(concurrency);
         factory.setSessionTransacted(true);
 
+        return factory;
+    }
+
+    @Bean
+    public ActiveMQConnectionFactory activeMQConnectionFactory() {
+        ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory();
+        factory.setBrokerURL(brokerUrl);
+        factory.setUserName(username);
+        factory.setPassword(password);
+        factory.setTrustAllPackages(trustAllPackages);
+
+        RedeliveryPolicy policy = new RedeliveryPolicy();
+        policy.setMaximumRedeliveries(maximumRedeliveries);
+        policy.setInitialRedeliveryDelay(initialRedeliveryDelay);
+        policy.setRedeliveryDelay(redeliveryDelay);
+        policy.setUseExponentialBackOff(useExponentialBackoff);
+
+        factory.setRedeliveryPolicy(policy);
         return factory;
     }
 

--- a/src/main/java/talento/futuro/iotapidev/config/ActiveMQConfig.java
+++ b/src/main/java/talento/futuro/iotapidev/config/ActiveMQConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.jms.annotation.EnableJms;
 import org.springframework.jms.config.DefaultJmsListenerContainerFactory;
+import org.springframework.jms.support.converter.SimpleMessageConverter;
 
 @Configuration
 @EnableJms
@@ -24,5 +25,10 @@ public class ActiveMQConfig {
         factory.setSessionTransacted(true);
 
         return factory;
+    }
+
+    @Bean
+    public SimpleMessageConverter simpleMessageConverter() {
+        return new SimpleMessageConverter();
     }
 }

--- a/src/main/java/talento/futuro/iotapidev/config/ActiveMQConfig.java
+++ b/src/main/java/talento/futuro/iotapidev/config/ActiveMQConfig.java
@@ -18,7 +18,7 @@ public class ActiveMQConfig {
     private String concurrency;
 
     @Bean
-    public DefaultJmsListenerContainerFactory jmsListenerContainerFactory (ConnectionFactory connectionFactory) {
+    public DefaultJmsListenerContainerFactory jmsTransactionalContainerFactory (ConnectionFactory connectionFactory) {
         DefaultJmsListenerContainerFactory factory = new DefaultJmsListenerContainerFactory();
         factory.setConnectionFactory(connectionFactory);
         factory.setConcurrency(concurrency);

--- a/src/main/java/talento/futuro/iotapidev/consumer/ActiveMQConsumer.java
+++ b/src/main/java/talento/futuro/iotapidev/consumer/ActiveMQConsumer.java
@@ -26,7 +26,8 @@ public class ActiveMQConsumer implements MessageConsumer {
         log.info("ActiveMQConsumer Service has started!");
     }
 
-    @JmsListener(destination = "${app.activemq.queue.myQueue}")
+    @JmsListener(destination = "${app.activemq.queue.myQueue}",
+            containerFactory = "jmsTransactionalContainerFactory")
     public void getMessageFromQueue(Message message) {
         String stringMessage;
         try {

--- a/src/main/java/talento/futuro/iotapidev/consumer/ActiveMQConsumer.java
+++ b/src/main/java/talento/futuro/iotapidev/consumer/ActiveMQConsumer.java
@@ -8,7 +8,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.jms.annotation.JmsListener;
 import org.springframework.jms.support.converter.SimpleMessageConverter;
 import org.springframework.stereotype.Service;
+import talento.futuro.iotapidev.exception.InvalidJSONException;
 import talento.futuro.iotapidev.exception.InvalidMessageTypeException;
+import talento.futuro.iotapidev.exception.InvalidSensorApiKeyException;
 import talento.futuro.iotapidev.service.PayloadProcessor;
 
 @Slf4j
@@ -33,7 +35,16 @@ public class ActiveMQConsumer implements MessageConsumer {
             log.error("Error processing message", e);
             throw new InvalidMessageTypeException();
         }
-        process(stringMessage);
+        try {
+            process(stringMessage);
+        } catch (InvalidJSONException e) {
+            log.warn("Invalid JSON message: {}", stringMessage);
+        } catch (InvalidSensorApiKeyException e) {
+            log.warn("Message with an invalid API key: {}", stringMessage);
+        } catch (Exception e) {
+            log.error("Unexpected error processing message: {}", stringMessage, e);
+            throw e;
+        }
     }
 
     @Override

--- a/src/main/java/talento/futuro/iotapidev/consumer/MessageConsumer.java
+++ b/src/main/java/talento/futuro/iotapidev/consumer/MessageConsumer.java
@@ -1,7 +1,5 @@
 package talento.futuro.iotapidev.consumer;
 
-import jakarta.jms.Message;
-
 public interface MessageConsumer {
-    void consume(Message message);
+    void process(String message);
 }

--- a/src/main/resources/activemq.properties
+++ b/src/main/resources/activemq.properties
@@ -5,3 +5,7 @@ spring.activemq.packages.trust-all=true
 #customs:
 app.activemq.listener.concurrency=1-1
 app.activemq.queue.myQueue=${AMQ_BROKER_QUEUE:p1-g2}
+app.activemq.redelivery.maximum-redeliveries = -1
+app.activemq.redelivery.initial-redelivery-delay = 5000
+app.activemq.redelivery.redelivery-delay = 5000
+app.activemq.redelivery.use-exponential-backoff = false


### PR DESCRIPTION
- Fix to enable message consumption from queues.
- Decouple MessageConsumer and PayloadProcessor from JMS (Java Message Service) to separate transport logic from business logic.
- Prevent message redelivery for known non-recoverable exceptions, such as invalid JSON or messages containing an invalid API key.
- Allow configuration of maximum retries and delays for redelivery in ActiveMQ.