### PR TITLE
Allow switching between topic and queue in ActiveMQ

### DIFF
--- a/src/main/java/talento/futuro/iotapidev/config/ActiveMQConfig.java
+++ b/src/main/java/talento/futuro/iotapidev/config/ActiveMQConfig.java
@@ -16,12 +16,15 @@ public class ActiveMQConfig {
     @Value("${app.activemq.listener.concurrency}")
     private String concurrency;
 
+    @Value("${app.activemq.pub-sub-domain:false}")
+    private Boolean pubSubDomain;
+
     @Bean
     public DefaultJmsListenerContainerFactory jmsListenerContainerFactory (ConnectionFactory connectionFactory) {
         DefaultJmsListenerContainerFactory factory = new DefaultJmsListenerContainerFactory();
         factory.setConnectionFactory(connectionFactory);
         factory.setConcurrency(concurrency);
-        factory.setPubSubDomain(true);
+        factory.setPubSubDomain(pubSubDomain);
         factory.setSessionTransacted(true);
 
         return factory;

--- a/src/main/java/talento/futuro/iotapidev/consumer/ActiveMQConsumer.java
+++ b/src/main/java/talento/futuro/iotapidev/consumer/ActiveMQConsumer.java
@@ -21,7 +21,7 @@ public class ActiveMQConsumer implements MessageConsumer {
     }
 
     @Override
-    @JmsListener(destination = "${app.activemq.queue.myQueue}")
+    @JmsListener(destination = "${app.activemq.destination}")
     public void consume(Message message) {
         payloadProcessor.extractSensorData(message);
     }

--- a/src/main/resources/activemq.properties
+++ b/src/main/resources/activemq.properties
@@ -4,4 +4,7 @@ spring.activemq.password=${AMQ_BROKER_PASSWORD:admin}
 spring.activemq.packages.trust-all=true
 #customs:
 app.activemq.listener.concurrency=1-1
-app.activemq.queue.myQueue=${AMQ_BROKER_QUEUE:p1-g2}
+# destination: queue or topic
+app.activemq.destination=${AMQ_BROKER_QUEUE:p1-g2}
+# pub-sub-domain: true for topics, false for queues
+app.activemq.pub-sub-domain=false


### PR DESCRIPTION
Externalize pub-sub-domain to support switching between queue and topic in ActiveMQ.